### PR TITLE
Refactor : hashing and save user code

### DIFF
--- a/src/main/java/com/example/demo/global/rabbitmq/RabbitMqService.java
+++ b/src/main/java/com/example/demo/global/rabbitmq/RabbitMqService.java
@@ -9,7 +9,7 @@ import com.example.demo.global.enums.SubmissionStatus;
 import com.example.demo.problem.controller.request.SubmissionRequest;
 import com.example.demo.problem.domain.Problem;
 import com.example.demo.submission.domain.Submission;
-import com.example.demo.submission.domain.api.SubmissionRepository;
+import com.example.demo.submission.domain.api.SubmissionApiRepository;
 import com.example.demo.user.domain.User;
 import com.example.demo.user.domain.api.UserApiRepository;
 import lombok.RequiredArgsConstructor;
@@ -44,7 +44,7 @@ public class RabbitMqService {
     private String routingKey;
 
     private final RabbitTemplate rabbitTemplate;
-    private final SubmissionRepository submissionRepository;
+    private final SubmissionApiRepository submissionRepository;
     private final UserApiRepository userApiRepository;
 
     /**
@@ -63,50 +63,50 @@ public class RabbitMqService {
      * 1. Queue 에서 메세지를 받도록 함.
      * 2. 임의로 messageDto를 Object 타입으로 받았지만, 실제로는 DTO 클래스를 사용하여 타입을 지정.
      **/
-    @RabbitListener(queues = "${rabbitmq.queue.name}")
-    @Transactional
-    public void receiveMessage(SubmissionMessageDto messageDto) {
-        log.info("************ messagge receive: {}",messageDto.getProblemDto());
-        ProblemDto problemDto = messageDto.getProblemDto();
-        UserDto userDto = messageDto.getUserDto();
-        SubmissionRequest request = messageDto.getRequest();
-
-        List<TestcaseDto> testcases = problemDto.getTestcases();
-
-        String executableCode = generateExecutableCode(request.getCode(), testcases);
-        /* Todo: 실제로 샌드박스 환경에서 실행하는 코드로 변경하고 요청을 보내야합니다.
-        String stdout = sandboxApi.execute(executableCode);
-        List<Boolean> testResults = Arrays.stream(
-                        stdout.replaceAll("[\\[\\] ]", "").split(","))
-                .map(Boolean::parseBoolean)
-                .toList();
-        */
-
-        List<SubmissionStatus> testResults = new ArrayList<>();
-        for (int i=0; i < testcases.size(); i++) {
-            testResults.add(SubmissionStatus.SUCCESS);
-        }
-
-        double runtime = new Random().nextDouble(0.1, 2.0); // Simulate runtime in seconds
-        double memory = new Random().nextDouble(10, 100); // Simulate memory usage in MB
-        sleep((int)runtime*1000); // Simulate execution time
-
-        User user = User.toEntity(userDto.getId(), userDto.getNickname());
-        Problem problem = Problem.toEntity(problemDto);
-
-        // 결과 받아서 저장하기
-        Submission submission = Submission.toEntity(
-                request.getCode(),
-                request.getCodingLanguage(),
-                SubmissionStatus.SUCCESS, // 실제로는 testResults에 따라 다르게 설정해야 합니다.
-                runtime,
-                memory,
-                user,
-                problem
-        );
-
-        submissionRepository.save(submission);
-    }
+//    @RabbitListener(queues = "${rabbitmq.queue.name}")
+//    @Transactional
+//    public void receiveMessage(SubmissionMessageDto messageDto) {
+//        log.info("************ messagge receive: {}",messageDto.getProblemDto());
+//        ProblemDto problemDto = messageDto.getProblemDto();
+//        UserDto userDto = messageDto.getUserDto();
+//        SubmissionRequest request = messageDto.getRequest();
+//
+//        List<TestcaseDto> testcases = problemDto.getTestcases();
+//
+//        String executableCode = generateExecutableCode(request.getCode(), testcases);
+//        /* Todo: 실제로 샌드박스 환경에서 실행하는 코드로 변경하고 요청을 보내야합니다.
+//        String stdout = sandboxApi.execute(executableCode);
+//        List<Boolean> testResults = Arrays.stream(
+//                        stdout.replaceAll("[\\[\\] ]", "").split(","))
+//                .map(Boolean::parseBoolean)
+//                .toList();
+//        */
+//
+//        List<SubmissionStatus> testResults = new ArrayList<>();
+//        for (int i=0; i < testcases.size(); i++) {
+//            testResults.add(SubmissionStatus.SUCCESS);
+//        }
+//
+//        double runtime = new Random().nextDouble(0.1, 2.0); // Simulate runtime in seconds
+//        double memory = new Random().nextDouble(10, 100); // Simulate memory usage in MB
+//        sleep((int)runtime*1000); // Simulate execution time
+//
+//        User user = User.toEntity(userDto.getId(), userDto.getNickname());
+//        Problem problem = Problem.toEntity(problemDto);
+//
+//        // 결과 받아서 저장하기
+//        Submission submission = Submission.of(
+//                request.getCode(),
+//                request.getCodingLanguage(),
+//                SubmissionStatus.SUCCESS, // 실제로는 testResults에 따라 다르게 설정해야 합니다.
+//                runtime,
+//                memory,
+//                user,
+//                problem
+//        );
+//
+//        submissionRepository.save(submission);
+//    }
 
     /**
      * 샌드박스 환경에서 실행할 수 있는 Java 프로그램 코드를 생성합니다.

--- a/src/main/java/com/example/demo/problem/controller/ProblemController.java
+++ b/src/main/java/com/example/demo/problem/controller/ProblemController.java
@@ -52,7 +52,8 @@ public class ProblemController {
     @PostMapping("/problems/{problemId}/submission")
     public ApiResponse<SubmissionResponse> submitProblem(
             @PathVariable("problemId") long problemId,
-            @RequestBody SubmissionRequest request) {
-        return ApiResponse.success(problemService.submitProblem(problemId, request));
+            @RequestBody SubmissionRequest request,
+            @RequestHeader(value = "idempotency-key") String idempotencyKey) {
+        return ApiResponse.success(problemService.submitProblem(problemId, request, idempotencyKey));
     }
 }

--- a/src/main/java/com/example/demo/submission/domain/Submission.java
+++ b/src/main/java/com/example/demo/submission/domain/Submission.java
@@ -8,6 +8,7 @@ import jakarta.persistence.*;
 import lombok.*;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Entity
 @Table(name = "submission")
@@ -23,6 +24,8 @@ public class Submission {
 
     private String code;
 
+    private String encodedCode; //Sha256 encoded code for duplicate check
+
     @Enumerated(EnumType.STRING)
     private CodingLanguages language;
 
@@ -34,6 +37,11 @@ public class Submission {
     private double memory;  // MB
 
     private LocalDateTime submittedAt;
+
+    private SubmissionStatus codeResult;
+
+    @Column(columnDefinition = "TEXT")
+    private String testResults;
 
     @ManyToOne
     @JoinColumn(name = "user_id")
@@ -53,6 +61,8 @@ public class Submission {
                 .runtime(runtime)
                 .memory(memory)
                 .submittedAt(LocalDateTime.now())
+                .codeResult(codeResult)
+                .testResults(testResults)
                 .user(user)
                 .problem(problem)
                 .build();

--- a/src/main/java/com/example/demo/submission/domain/api/SubmissionApiRepository.java
+++ b/src/main/java/com/example/demo/submission/domain/api/SubmissionApiRepository.java
@@ -1,7 +1,10 @@
-package com.example.demo.submission.api;
+package com.example.demo.submission.domain.api;
 
 import com.example.demo.submission.domain.Submission;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface SubmissionApiRepository extends JpaRepository<Submission, Long> {
+    Optional<Submission> findByEncodedCode(String encodedCode);
 }

--- a/src/main/java/com/example/demo/submission/domain/api/SubmissionRepository.java
+++ b/src/main/java/com/example/demo/submission/domain/api/SubmissionRepository.java
@@ -1,9 +1,0 @@
-package com.example.demo.submission.domain.api;
-
-import com.example.demo.submission.domain.Submission;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
-
-@Repository
-public interface SubmissionRepository extends JpaRepository<Submission, Long> {
-}


### PR DESCRIPTION
closes #26 

✅ 최종 결론
동일한 코드 제출을 처리하기 위한 SHA256 해시 기반 식별 및 멱등성 키(Idempotency-Key) 활용 전략은, 성능 최적화 측면에서 효과적입니다. 실제로 약 1초 이상의 요청 시간을 절감할 수 있으며, 빠르게 연속 요청이 발생하는 경우에도 안정적으로 중복 처리를 차단할 수 있습니다.

그러나 이 방식은 다음과 같은 명확한 비용과 복잡성 증가를 수반합니다:

해시 컬럼 저장에 따른 디스크 사용량 증가

SubmissionApiRepository.findByEncodedCode(..) 조회로 인한 추가 DB I/O

인덱싱 미적용 시 성능 저하 (풀테이블 스캔), 인덱스 적용 시 쓰기 오버헤드 발생

또한, 사용자 행동 데이터를 기반으로 동일 코드 재제출 빈도가 낮을 것으로 예상된다면, 이 최적화 기능이 실질적인 이점을 주지 못할 수 있습니다.

따라서,

✅ 현재 서버 리소스와 처리량으로 기본 제출 방식만으로도 충분히 안정적이라면, 해당 기능은 도입을 보류하고 향후 트래픽 증가 시점에 다시 도입을 검토하는 것이 바람직합니다.

반대로,

❗ 실시간 응답 속도에 민감하거나, 동일 코드 제출이 빈번하게 발생하는 서비스 구조라면, 본 개선안을 적극 도입하여 서버 부하와 처리 지연을 줄이는 전략으로 활용할 수 있습니다.
따라서, 적용하지 않기로 결정했습니다.