### PR TITLE
Leaderboard 조회 오류 수정 및 Leaderboard & Redis 데이터 저장 프로세스 추가

### DIFF
--- a/src/main/java/com/example/demo/DemoApplication.java
+++ b/src/main/java/com/example/demo/DemoApplication.java
@@ -9,9 +9,7 @@ import org.springframework.cache.annotation.EnableCaching;
 @SpringBootApplication
 @EnableCaching
 public class DemoApplication {
-
 	public static void main(String[] args) {
 		SpringApplication.run(DemoApplication.class, args);
 	}
-
 }

--- a/src/main/java/com/example/demo/contest/domain/api/ContestRepository.java
+++ b/src/main/java/com/example/demo/contest/domain/api/ContestRepository.java
@@ -1,0 +1,9 @@
+package com.example.demo.contest.domain.api;
+
+import com.example.demo.contest.domain.Contest;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ContestRepository extends JpaRepository<Contest, Long> {
+}

--- a/src/main/java/com/example/demo/leaderboard/application/LeaderBoardRedisService.java
+++ b/src/main/java/com/example/demo/leaderboard/application/LeaderBoardRedisService.java
@@ -8,6 +8,7 @@ import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.ZSetOperations;
 import org.springframework.stereotype.Service;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -46,6 +47,9 @@ public class LeaderBoardRedisService {
     public void addScore(long contestId, long userId, int score) {
         String key = "leaderboard:" + contestId;
         redisTemplate.opsForZSet().add(key, String.valueOf(userId), score);
-        redisTemplate.opsForZSet().removeRange(key, 50, -1);
+        //redisTemplate.opsForZSet().removeRange(key, 50, -1);
+
+        //  마지막 제출자가 낸 시간으로 부터 1시간 후 자동으로 만료되도록 설정.
+        redisTemplate.expire(key, Duration.ofHours(1));
     }
 }

--- a/src/main/java/com/example/demo/leaderboard/application/LeaderBoardService.java
+++ b/src/main/java/com/example/demo/leaderboard/application/LeaderBoardService.java
@@ -37,20 +37,20 @@ public class LeaderBoardService {
         List<RankingEntry> rankingEntries = leaderBoardRedisService.getTopN(contestId, 50);
 
         // 1. Redis에 데이터가 없다면
-        if (rankingEntries.isEmpty()) {
-            // 2. RDB에서 조회
-            List<RankingEntry> entriesFromRDB = leaderBoardRepository.getTop50LeaderBoardByContestId(contestId)
-                    .stream()
-                    .map(RankingEntry::from)
-                    .toList();
-
-            // 3. Redis에 적재
-            for (RankingEntry entry : entriesFromRDB) {
-                leaderBoardRedisService.addScore(contestId, entry.getUserId(), entry.getScore());
-            }
-
-            rankingEntries = entriesFromRDB;
-        }
+//        if (rankingEntries.isEmpty()) {
+//            // 2. RDB에서 조회
+//            List<RankingEntry> entriesFromRDB = leaderBoardRepository.getTop50LeaderBoardByContestId(contestId)
+//                    .stream()
+//                    .map(RankingEntry::from)
+//                    .toList();
+//
+//            // 3. Redis에 적재
+//            for (RankingEntry entry : entriesFromRDB) {
+//                leaderBoardRedisService.addScore(contestId, entry.getUserId(), entry.getScore());
+//            }
+//
+//            rankingEntries = entriesFromRDB;
+//        }
 
         return LeaderBoardResponse.from(rankingEntries);
     }

--- a/src/main/java/com/example/demo/leaderboard/controller/LeaderBoardController.java
+++ b/src/main/java/com/example/demo/leaderboard/controller/LeaderBoardController.java
@@ -13,15 +13,15 @@ public class LeaderBoardController {
 
     private final LeaderBoardService leaderBoardService;
 
-    @GetMapping("/v1/contests/{contest_id}/leaderboard")
-    public LeaderBoardResponse getLeaderBoardFromRdb(@PathVariable("contest_id") Long contestId) {
-        LeaderBoardResponse response = leaderBoardService.getLeaderBoardInfo(contestId);
-        return response;
-    }
+//    @GetMapping("/v1/contests/{contest_id}/leaderboard")
+//    public LeaderBoardResponse getLeaderBoardFromRdb(@PathVariable("contest_id") Long contestId) {
+//        LeaderBoardResponse response = leaderBoardService.getLeaderBoardInfo(contestId);
+//        return response;
+//    }
 
-    @GetMapping("/v1/redis/contests/{contest_id}/leaderboard")
-    public LeaderBoardResponse getLeaderBoardWithCache(@PathVariable("contest_id") String contestId) {
-        LeaderBoardResponse response = leaderBoardService.getLeaderBoardWithCache(Long.valueOf(contestId));
+    @GetMapping("/v1/contests/{contest_id}/leaderboard")
+    public LeaderBoardResponse getLeaderBoardWithCache(@PathVariable("contest_id") Long contestId) {
+        LeaderBoardResponse response = leaderBoardService.getLeaderBoardWithCache(contestId);
         return response;
     }
 }

--- a/src/main/java/com/example/demo/leaderboard/domain/LeaderBoard.java
+++ b/src/main/java/com/example/demo/leaderboard/domain/LeaderBoard.java
@@ -30,4 +30,14 @@ public class LeaderBoard {
     private int score;
 
     private long timeTaken; // in seconds
+
+    public static LeaderBoard toEntity(int score, long timeTaken, Contest contest, User user) {
+        LeaderBoard leaderboard = new LeaderBoard();
+        leaderboard.contest = contest;
+        leaderboard.user = user;
+        leaderboard.score = score;
+        leaderboard.timeTaken = timeTaken;
+        return leaderboard;
+    }
+
 }

--- a/src/main/java/com/example/demo/leaderboard/domain/api/LeaderBoardRepository.java
+++ b/src/main/java/com/example/demo/leaderboard/domain/api/LeaderBoardRepository.java
@@ -30,7 +30,7 @@ public interface LeaderBoardRepository extends JpaRepository<LeaderBoard, Long> 
              , user_id
              , score
              , time_taken    
-          from LeaderBoard
+          from leaderboard
          where contest_id=:contestId 
         order by score desc
             limit 50

--- a/src/main/java/com/example/demo/problem/application/ProblemService.java
+++ b/src/main/java/com/example/demo/problem/application/ProblemService.java
@@ -1,11 +1,16 @@
 package com.example.demo.problem.application;
 
+import com.example.demo.contest.domain.Contest;
+import com.example.demo.contest.domain.api.ContestRepository;
 import com.example.demo.global.common.ProblemDto;
 import com.example.demo.global.common.ProblemDtoMapper;
 import com.example.demo.global.common.SubmissionMessageDto;
 import com.example.demo.global.common.UserDto;
 import com.example.demo.global.enums.SubmissionStatus;
 import com.example.demo.global.rabbitmq.RabbitMqService;
+import com.example.demo.leaderboard.application.LeaderBoardRedisService;
+import com.example.demo.leaderboard.domain.LeaderBoard;
+import com.example.demo.leaderboard.domain.api.LeaderBoardRepository;
 import com.example.demo.problem.controller.request.SubmissionRequest;
 import com.example.demo.problem.controller.response.ProblemDetailResponse;
 import com.example.demo.problem.controller.response.ProblemResponse;
@@ -18,17 +23,20 @@ import com.example.demo.testcases.domain.Testcase;
 import com.example.demo.user.domain.User;
 import com.example.demo.user.domain.api.UserApiRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class ProblemService {
@@ -36,6 +44,9 @@ public class ProblemService {
     private final ProblemApiRepository problemRepository;
     private final UserApiRepository userRepository;
     private final SubmissionApiRepository submissionRepository;
+    private final LeaderBoardRepository leaderBoardRepository;
+    private final LeaderBoardRedisService leaderBoardRedisService;
+    private final ContestRepository contestRepository;
     private final RabbitMqService rabbitMqService;
 
     public List<ProblemResponse> getProblems(long start, long end) {
@@ -78,10 +89,11 @@ public class ProblemService {
         return ProblemDetailResponse.from(problem);
     }
 
+    @Transactional
     public SubmissionResponse submitProblem(Long problemId, SubmissionRequest request) {
         Problem problem = problemRepository.findById(problemId)
                 .orElseThrow(() -> new IllegalArgumentException("문제가 존재하지 않습니다."));
-        User user = userRepository.findById(1L)
+        User user = userRepository.findById(request.getUserId())
                 .orElseThrow(() -> new IllegalArgumentException("유저가 존재하지 않습니다."));
 
         List<Testcase> testcases = problem.getTestcases();
@@ -100,7 +112,7 @@ public class ProblemService {
         }
         double runtime = new Random().nextDouble(0.1, 2.0); // Simulate runtime in seconds
         double memory = new Random().nextDouble(10, 100); // Simulate memory usage in MB
-        sleep((int)runtime*1000); // Simulate execution time
+        //sleep((int)runtime*1000); // Simulate execution time
 
 
         // 결과 받아서 저장하기
@@ -114,6 +126,23 @@ public class ProblemService {
                 problem
         );
         submissionRepository.save(submission);
+
+        Long contestId = request.getContestId();
+        if (contestId != null) {
+            Contest contest = contestRepository.findById(contestId).orElseThrow();
+            // 테스트용 코드로 score를 500 ~ 999점 사이로 넣는다.
+            int score = 500 + new Random().nextInt(999 - 500 + 1);
+            // 100~ 4000 사이로 랜덤값이 나오는데 score에 따라서 계산됨.
+            long timeTaken = (long) (4000 - (4000 - 100) * (new Random().nextInt(1000) / 999.0));
+
+            // save user score info to Redis
+            leaderBoardRedisService.addScore(contestId,user.getId(), score);
+
+            // save leaderboard info to the RDB
+            LeaderBoard leaderBoard = LeaderBoard.toEntity(score, timeTaken, contest, user);
+            LeaderBoard save = leaderBoardRepository.save(leaderBoard);
+            log.info("Leaderboard saved User Id : {}",save.getUser().getId());
+        }
 
         return SubmissionResponse.of(testResults);
     }

--- a/src/main/java/com/example/demo/problem/controller/request/SubmissionRequest.java
+++ b/src/main/java/com/example/demo/problem/controller/request/SubmissionRequest.java
@@ -8,9 +8,22 @@ import lombok.Getter;
 public class SubmissionRequest {
     private CodingLanguages codingLanguage;
     private String code;
+    private Long contestId;
+    private Long userId;
 
-    public SubmissionRequest(CodingLanguages codingLanguage, String code) {
+    public SubmissionRequest() {
+    }
+
+    public SubmissionRequest(CodingLanguages codingLanguage, String code, Long userId) {
         this.codingLanguage = codingLanguage;
         this.code = code;
+        this.userId = userId;
+    }
+
+    public SubmissionRequest(CodingLanguages codingLanguage, Long contestId, String code, Long userId) {
+        this.codingLanguage = codingLanguage;
+        this.contestId = contestId;
+        this.code = code;
+        this.userId = userId;
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,5 @@
 spring:
   datasource:
-    # 로컬 MySQL
     url: jdbc:mysql://${MYSQL_HOST}:3306/${MYSQL_DB}?serverTimezone=UTC&characterEncoding=UTF-8
     username: ${MYSQL_USER}
     password: ${MYSQL_PASSWORD}
@@ -24,10 +23,10 @@ spring:
     redis:
       host: ${REDIS_HOST}
       port: 6379
-#      host: localhost
-#      port: 6379
+  #      host: localhost
+  #      port: 6379
 
-# rabbitmq 설정
+  # rabbitmq 설정
   rabbitmq:
     host: ${RABBITMQ_HOST} # RabbitMQ host ip
     port: 5672 # RabbitMQ port

--- a/src/test/java/com/example/demo/application/AppControllerTest.java
+++ b/src/test/java/com/example/demo/application/AppControllerTest.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.web.client.RestClient;
+import org.springframework.web.reactive.function.BodyInserters;
 
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -20,33 +21,65 @@ class AppControllerTest {
     RestClient restClient = RestClient.create("http://localhost:8080");
 
     @Test
-    public void healthCheck() {
-        String body = restClient.get()
-                .uri("/health")
-                .retrieve()
-                .body(String.class);
+    void getLeaderBoardInfoTest() {
+        long contestId = 2L;
+        long[] problemIds = {2L, 4L, 5L};
+        String userCode = """
+            public class Main {
+                public static void main(String[] args) {
+                    System.out.println("[true]");
+                }
+            }
+            """;
+        // 1. 유저 1~100번 반복
+        for (long userId = 1; userId <= 75; userId++) {
+            SubmissionRequest request = new SubmissionRequest(CodingLanguages.JAVA, contestId, userCode, userId);
 
-        System.out.println(body);
+            restClient.post()
+                    .uri("/problems/3/submission")
+                    .body(request)
+                    .retrieve()
+                    .body(ApiResponse.class);
+
+            // 2. 50번째 유저가 제출 끝났으면 leaderboard 조회
+            if (userId == 50) {
+                System.out.println("==== 50번째 유저 제출 완료 후 Leaderboard ====");
+                LeaderBoardResponse leaderboard = restClient.get()
+                        .uri("/v1/contests/{contest_id}/leaderboard", contestId)
+                        .retrieve()
+                        .body(LeaderBoardResponse.class);
+
+                printLeaderboard(leaderboard);
+            }
+
+            // 3. 75번째 유저가 제출 끝났으면 leaderboard 조회
+            if (userId == 75) {
+                System.out.println("==== 75번째 유저 제출 완료 후 Leaderboard ====");
+                LeaderBoardResponse leaderboard = restClient.get()
+                        .uri("/v1/contests/{contest_id}/leaderboard", contestId)
+                        .retrieve()
+                        .body(LeaderBoardResponse.class);
+
+                printLeaderboard(leaderboard);
+            }
+        }
+
+
     }
 
-    @Test
-    void getLeaderBoardInfoTest() {
-        LeaderBoardResponse body = restClient.get()
-                .uri("/v1/contests/{contest_id}/leaderboard", 1)
-                .retrieve()
-                .body(LeaderBoardResponse.class);
-//
-//        for(RankingEntry ranking : body.getRanking()) {
-//            System.out.println("Id : " + ranking.getUserId());
-//            System.out.println("score : " + ranking.getScore());
-//        }
-
+    private void printLeaderboard(LeaderBoardResponse leaderboard) {
+        List<RankingEntry> rankings = leaderboard.getRanking();
+        for (int i = 0; i < rankings.size(); i++) {
+            RankingEntry entry = rankings.get(i);
+            System.out.printf("%d위: UserId=%d, Score=%d%n",
+                    i + 1, entry.getUserId(), entry.getScore());
+        }
     }
 
     @Test
     void getLeaderBoardInfoWithRedisTest() {
         LeaderBoardResponse response = restClient.get()
-                .uri("/v1/redis/contests/{contest_id}/leaderboard", 1)
+                .uri("/v1/contests/{contest_id}/leaderboard", 2L)
                 .retrieve()
                 .body(LeaderBoardResponse.class);
 
@@ -55,15 +88,6 @@ class AppControllerTest {
             System.out.println("score : " + ranking.getScore());
         }
 
-        LeaderBoardResponse response2 = restClient.get()
-                .uri("/v1/redis/contests/{contest_id}/leaderboard", 1)
-                .retrieve()
-                .body(LeaderBoardResponse.class);
-
-        for(RankingEntry ranking : response2.getRanking()) {
-            System.out.println("Id : " + ranking.getUserId());
-            System.out.println("score : " + ranking.getScore());
-        }
     }
 
     @Test
@@ -79,7 +103,7 @@ class AppControllerTest {
             """;
 
         // 2️⃣ SubmissionRequest 생성
-        SubmissionRequest request = new SubmissionRequest(CodingLanguages.JAVA, userCode);
+        SubmissionRequest request = new SubmissionRequest(CodingLanguages.JAVA, 2L, userCode, 102L);
 
         // 3️⃣ POST 요청 보내기
         ApiResponse<SubmissionResponse>  response = restClient.post()

--- a/src/test/java/com/example/demo/problem/controller/ProblemControllerTest.java
+++ b/src/test/java/com/example/demo/problem/controller/ProblemControllerTest.java
@@ -57,7 +57,7 @@ class ProblemControllerTest {
 
     @Test
     void submitProblem() {
-        SubmissionRequest request = new SubmissionRequest(CodingLanguages.JAVA, "print('Hello, World!')");
+        SubmissionRequest request = new SubmissionRequest(CodingLanguages.JAVA, "print('Hello, World!')",1L);
 
         ApiResponse response = restClient.post()
                 .uri("/problems/1/submission")


### PR DESCRIPTION
Leaderboard 조회 시 AWS RDB 연동 오류
- 문제: 연동된 AWS RDB의 테이블명(leaderboard)과 애플리케이션 단에서 사용하는 테이블명(LeaderBoard)이 달라 오류가 발생.
- 해결: 테이블명을 LeaderBoard에서 leaderboard로 수정하여 일관성 유지.

실시간 Leaderboard 조회를 위한 프로세스 수정
  Leaderboard 데이터 조회 프로세스
  - 변경 전: Leaderboard 조회 시 Redis에 데이터가 없는 경우 RDB에서 조회.
  - 변경 후: Leaderboard 조회 시 Redis에서만 데이터 조회하도록 변경 (RDB 조회 로직 삭제).
  
  Problem Submission 프로세스
  - 변경 전: 사용자가 문제를 풀고 제출하면 submission 데이터만 저장.
  - 변경 후: 사용자가 문제를 풀고 제출하면 submission, Leaderboard, 그리고 Redis에 데이터 모두 저장.



