### PR TITLE
Feat/submit mq

### DIFF
--- a/src/main/java/com/example/demo/DemoApplication.java
+++ b/src/main/java/com/example/demo/DemoApplication.java
@@ -1,5 +1,6 @@
 package com.example.demo;
 
+import org.springframework.amqp.rabbit.annotation.EnableRabbit;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
@@ -8,6 +9,7 @@ import org.springframework.cache.annotation.EnableCaching;
 @ConfigurationPropertiesScan
 @SpringBootApplication
 @EnableCaching
+@EnableRabbit
 public class DemoApplication {
 	public static void main(String[] args) {
 		SpringApplication.run(DemoApplication.class, args);

--- a/src/main/java/com/example/demo/global/common/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/demo/global/common/GlobalExceptionHandler.java
@@ -43,4 +43,11 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ApiResponse<Void>> handleAllExceptions(Exception ex) {
         return new ResponseEntity<>(ApiResponse.fail("An unexpected error occurred: " + ex.getMessage()), HttpStatus.INTERNAL_SERVER_ERROR);
     }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<ApiResponse<Void>> handleIllegalArgument(IllegalArgumentException ex) {
+        // ex.getMessage() 에는 "Submission not found with id: ..." 같은 메시지가 담겨있겠죠
+        return new ResponseEntity<>(ApiResponse.fail("Database resource not found: " + ex.getMessage()), HttpStatus.NOT_FOUND
+        );
+    }
 }

--- a/src/main/java/com/example/demo/global/enums/SubmissionStatus.java
+++ b/src/main/java/com/example/demo/global/enums/SubmissionStatus.java
@@ -2,7 +2,5 @@ package com.example.demo.global.enums;
 
 public enum SubmissionStatus {
     SUCCESS,
-    FAIL,
-    TIMEOUT,
     PENDING,
 }

--- a/src/main/java/com/example/demo/global/enums/SubmissionStatus.java
+++ b/src/main/java/com/example/demo/global/enums/SubmissionStatus.java
@@ -3,5 +3,6 @@ package com.example.demo.global.enums;
 public enum SubmissionStatus {
     SUCCESS,
     FAIL,
-    TIMEOUT
+    TIMEOUT,
+    PENDING,
 }

--- a/src/main/java/com/example/demo/global/rabbitmq/RabbitMqService.java
+++ b/src/main/java/com/example/demo/global/rabbitmq/RabbitMqService.java
@@ -1,17 +1,14 @@
 package com.example.demo.global.rabbitmq;
 
 
-import com.example.demo.global.common.ProblemDto;
-import com.example.demo.global.common.SubmissionMessageDto;
 import com.example.demo.global.common.TestcaseDto;
-import com.example.demo.global.common.UserDto;
 import com.example.demo.global.enums.SubmissionStatus;
-import com.example.demo.problem.controller.request.SubmissionRequest;
-import com.example.demo.problem.domain.Problem;
+import com.example.demo.leaderboard.application.LeaderBoardService;
+import com.example.demo.problem.controller.request.SubmissionRequestMessageDto;
+import com.example.demo.problem.controller.response.SubmissionResultMessageDto;
 import com.example.demo.submission.domain.Submission;
 import com.example.demo.submission.domain.api.SubmissionRepository;
-import com.example.demo.user.domain.User;
-import com.example.demo.user.domain.api.UserApiRepository;
+import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.amqp.rabbit.annotation.RabbitListener;
@@ -20,9 +17,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Random;
 
 /**
  * Queue 로 메세지를 발행할 때에는 RabbitTemplate 의 ConvertAndSend 메소드를 사용하고
@@ -34,18 +29,17 @@ import java.util.Random;
 @Service
 public class RabbitMqService {
 
-    @Value("${rabbitmq.queue.name}")
-    private String queueName;
 
     @Value("${rabbitmq.exchange.name}")
     private String exchangeName;
 
-    @Value("${rabbitmq.routing.key}")
-    private String routingKey;
+    @Value("${rabbitmq.request.routing.key}")
+    private String requestRoutingKey;
 
     private final RabbitTemplate rabbitTemplate;
+
     private final SubmissionRepository submissionRepository;
-    private final UserApiRepository userApiRepository;
+    private final LeaderBoardService leaderboardService;
 
     /**
      * 1. Queue 로 메세지를 발행
@@ -54,59 +48,30 @@ public class RabbitMqService {
      *
      * @return
      */
-    public void sendMessage(SubmissionMessageDto messageDto) {
-        log.info("************ messagge send: {}",messageDto.getProblemDto());
-        this.rabbitTemplate.convertAndSend(exchangeName,routingKey,messageDto);
+    public void sendMessage(SubmissionRequestMessageDto submissionRequestMessageDto) {
+        log.info("************ messagge send: {}", submissionRequestMessageDto.getSubmissionId());
+        this.rabbitTemplate.convertAndSend(exchangeName,requestRoutingKey,submissionRequestMessageDto);
     }
 
     /**
      * 1. Queue 에서 메세지를 받도록 함.
-     * 2. 임의로 messageDto를 Object 타입으로 받았지만, 실제로는 DTO 클래스를 사용하여 타입을 지정.
      **/
-//    @RabbitListener(queues = "${rabbitmq.queue.name}")
-//    @Transactional
-//    public void receiveMessage(SubmissionMessageDto messageDto) {
-//        log.info("************ messagge receive: {}",messageDto.getProblemDto());
-//        ProblemDto problemDto = messageDto.getProblemDto();
-//        UserDto userDto = messageDto.getUserDto();
-//        SubmissionRequest request = messageDto.getRequest();
-//
-//        List<TestcaseDto> testcases = problemDto.getTestcases();
-//
-//        String executableCode = generateExecutableCode(request.getCode(), testcases);
-//        /* Todo: 실제로 샌드박스 환경에서 실행하는 코드로 변경하고 요청을 보내야합니다.
-//        String stdout = sandboxApi.execute(executableCode);
-//        List<Boolean> testResults = Arrays.stream(
-//                        stdout.replaceAll("[\\[\\] ]", "").split(","))
-//                .map(Boolean::parseBoolean)
-//                .toList();
-//        */
-//
-//        List<SubmissionStatus> testResults = new ArrayList<>();
-//        for (int i=0; i < testcases.size(); i++) {
-//            testResults.add(SubmissionStatus.SUCCESS);
-//        }
-//
-//        double runtime = new Random().nextDouble(0.1, 2.0); // Simulate runtime in seconds
-//        double memory = new Random().nextDouble(10, 100); // Simulate memory usage in MB
-//        sleep((int)runtime*1000); // Simulate execution time
-//
-//        User user = User.toEntity(userDto.getId(), userDto.getNickname());
-//        Problem problem = Problem.toEntity(problemDto);
-//
-//        // 결과 받아서 저장하기
-//        Submission submission = Submission.toEntity(
-//                request.getCode(),
-//                request.getCodingLanguage(),
-//                SubmissionStatus.SUCCESS, // 실제로는 testResults에 따라 다르게 설정해야 합니다.
-//                runtime,
-//                memory,
-//                user,
-//                problem
-//        );
-//
-//        submissionRepository.save(submission);
-//    }
+    @Transactional
+    @RabbitListener(queues = "${rabbitmq.result.queue.name}")
+    public void handleResult(SubmissionResultMessageDto submissionResultMessageDto) {
+        // 1) 기존 Submission 엔티티 조회
+        Long submissionId = submissionResultMessageDto.getSubmissionId();
+        SubmissionStatus status = submissionResultMessageDto.getStatus();
+        Submission submission = submissionRepository.findById(submissionId)
+                .orElseThrow(() -> new EntityNotFoundException(
+                        "Submission not found: " + submissionId));
+
+        // 2) 상태 업데이트
+        submission.setStatus(status);// SUCCESS or FAILURE
+
+        submissionRepository.save(submission);
+        leaderboardService.saveLeaderboard( submissionResultMessageDto.getContestId(), submission.getUser());
+    }
 
     /**
      * 샌드박스 환경에서 실행할 수 있는 Java 프로그램 코드를 생성합니다.

--- a/src/main/java/com/example/demo/global/rabbitmq/config/RabbitMqConfig.java
+++ b/src/main/java/com/example/demo/global/rabbitmq/config/RabbitMqConfig.java
@@ -52,7 +52,7 @@ public class RabbitMqConfig {
      */
     @Bean
     public DirectExchange submissionExchange() {
-        return new DirectExchange(exchangeName, false, true);
+        return new DirectExchange(exchangeName);
     }
 
     /**

--- a/src/main/java/com/example/demo/global/rabbitmq/config/RabbitMqConfig.java
+++ b/src/main/java/com/example/demo/global/rabbitmq/config/RabbitMqConfig.java
@@ -6,7 +6,7 @@ import org.springframework.amqp.core.Binding;
 import org.springframework.amqp.core.BindingBuilder;
 import org.springframework.amqp.core.DirectExchange;
 import org.springframework.amqp.core.Queue;
-import org.springframework.amqp.rabbit.connection.CachingConnectionFactory;
+import org.springframework.amqp.rabbit.config.SimpleRabbitListenerContainerFactory;
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
@@ -21,49 +21,70 @@ public class RabbitMqConfig {
 
     private final RabbitMqProperties rabbitMqProperties;
 
-    @Value("${rabbitmq.queue.name}")
-    private String queueName;
+    @Value("${rabbitmq.request.queue.name}")
+    private String requestQueueName;
+
+    @Value("${rabbitmq.result.queue.name}")
+    private String resultQueueName;
 
     @Value("${rabbitmq.exchange.name}")
     private String exchangeName;
 
-    @Value("${rabbitmq.routing.key}")
-    private String routingKey;
+    // 라우팅 키 분리 (application.yml 에서 정의)
+    @Value("${rabbitmq.request.routing.key}")
+    private String requestRoutingKey;
+    @Value("${rabbitmq.result.routing.key}")
+    private String resultRoutingKey;
 
     // org.springframework.amqp.core.Queue
     @Bean
-    public Queue queue() {
-        return new Queue(queueName);
+    public Queue requestQueue() {
+        return new Queue(requestQueueName);
+    }
+
+    @Bean
+    public Queue resultQueue() {
+        return new Queue(resultQueueName);
     }
 
     /**
      * 지정된 Exchange 이름으로 Direct Exchange Bean 을 생성
      */
     @Bean
-    public DirectExchange directExchange() {
-        return new DirectExchange(exchangeName);
+    public DirectExchange submissionExchange() {
+        return new DirectExchange(exchangeName, false, true);
     }
 
     /**
-     * 주어진 Queue 와 Exchange 을 Binding 하고 Routing Key 을 이용하여 Binding Bean 생성
+     * requestQueue 와 Exchange 을 Binding 하고 requestRoutingKey Key 을 이용하여 Binding Bean 생성
      * Exchange 에 Queue 을 등록한다고 이해하자
      **/
     @Bean
-    public Binding binding(Queue queue, DirectExchange exchange) {
-        return BindingBuilder.bind(queue).to(exchange).with(routingKey);
+    public Binding requestBinding(Queue requestQueue, DirectExchange submissionExchange) {
+        return BindingBuilder.bind(requestQueue).to(submissionExchange).with(requestRoutingKey);
+    }
+
+    /**
+     * resultQueue 와 Exchange 을 Binding 하고 resultRoutingKey Key 을 이용하여 Binding Bean 생성
+     * Exchange 에 Queue 을 등록한다고 이해하자
+     **/
+    @Bean
+    public Binding resultBinding(Queue resultQueue, DirectExchange submissionExchange) {
+        return BindingBuilder.bind(resultQueue).to(submissionExchange).with(resultRoutingKey);
     }
 
     /**
      * RabbitMQ 연동을 위한 ConnectionFactory 빈을 생성하여 반환
      **/
     @Bean
-    public CachingConnectionFactory connectionFactory() {
-        CachingConnectionFactory connectionFactory = new CachingConnectionFactory();
-        connectionFactory.setHost(rabbitMqProperties.getHost());
-        connectionFactory.setPort(rabbitMqProperties.getPort());
-        connectionFactory.setUsername(rabbitMqProperties.getUsername());
-        connectionFactory.setPassword(rabbitMqProperties.getPassword());
-        return connectionFactory;
+    public SimpleRabbitListenerContainerFactory rabbitListenerContainerFactory(
+            ConnectionFactory cf,
+            MessageConverter converter) {
+        SimpleRabbitListenerContainerFactory factory =
+                new SimpleRabbitListenerContainerFactory();
+        factory.setConnectionFactory(cf);
+        factory.setMessageConverter(converter);
+        return factory;
     }
 
     /**

--- a/src/main/java/com/example/demo/leaderboard/application/LeaderBoardService.java
+++ b/src/main/java/com/example/demo/leaderboard/application/LeaderBoardService.java
@@ -1,20 +1,26 @@
 package com.example.demo.leaderboard.application;
 
 
+import com.example.demo.contest.domain.Contest;
+import com.example.demo.contest.domain.api.ContestRepository;
 import com.example.demo.leaderboard.controller.response.LeaderBoardResponse;
+import com.example.demo.leaderboard.domain.LeaderBoard;
 import com.example.demo.leaderboard.domain.RankingEntry;
 import com.example.demo.leaderboard.domain.api.LeaderBoardRepository;
+import com.example.demo.user.domain.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
 
 @Service
 @RequiredArgsConstructor
 public class LeaderBoardService {
     private final LeaderBoardRepository leaderBoardRepository;
     private final LeaderBoardRedisService leaderBoardRedisService;
+    private final ContestRepository contestRepository;
 
     public LeaderBoardResponse getLeaderBoardInfo(Long contestId) {
 
@@ -51,5 +57,27 @@ public class LeaderBoardService {
 //        }
 
         return LeaderBoardResponse.from(rankingEntries);
+    }
+
+    @Transactional
+    public void saveLeaderboard(Long contestId, User user) {
+
+        if (contestId != null) {
+            Contest contest = contestRepository.findById(contestId).orElseThrow();
+//            // 테스트용 코드로 score를 500 ~ 999점 사이로 넣는다.
+//            int score = 500 + new Random().nextInt(999 - 500 + 1);
+//            // 100~ 4000 사이로 랜덤값이 나오는데 score에 따라서 계산됨.
+//            long timeTaken = (long) (4000 - (4000 - 100) * (new Random().nextInt(1000) / 999.0));
+
+            int score = ThreadLocalRandom.current().nextInt(500, 999);
+            long timeTaken = ThreadLocalRandom.current().nextLong(100, 4000);
+
+            // save user score info to Redis
+            leaderBoardRedisService.addScore(contestId,user.getId(), score);
+
+            // save leaderboard info to the RDB
+            LeaderBoard leaderBoard = LeaderBoard.toEntity(score, timeTaken, contest, user);
+            leaderBoardRepository.save(leaderBoard);
+        }
     }
 }

--- a/src/main/java/com/example/demo/problem/application/ProblemService.java
+++ b/src/main/java/com/example/demo/problem/application/ProblemService.java
@@ -140,7 +140,7 @@ public class ProblemService {
     public SubmissionCreatedResponse submitProblem(Long problemId, SubmissionRequest request) {
         Problem problem = problemRepository.findById(problemId)
                 .orElseThrow(() -> new IllegalArgumentException("문제가 존재하지 않습니다."));
-        User user = userRepository.findById(1L)
+        User user = userRepository.findById(request.getUserId())
                 .orElseThrow(() -> new IllegalArgumentException("유저가 존재하지 않습니다."));
 
         double runtime =  ThreadLocalRandom.current().nextDouble(0.1, 2.0);

--- a/src/main/java/com/example/demo/problem/application/ProblemService.java
+++ b/src/main/java/com/example/demo/problem/application/ProblemService.java
@@ -1,20 +1,17 @@
 package com.example.demo.problem.application;
 
 
-import com.example.demo.global.common.ProblemDto;
-import com.example.demo.global.common.ProblemDtoMapper;
-import com.example.demo.global.common.SubmissionMessageDto;
-import com.example.demo.global.common.UserDto;
 import com.example.demo.global.enums.SubmissionStatus;
 import com.example.demo.global.rabbitmq.RabbitMqService;
 import com.example.demo.problem.controller.request.SubmissionRequest;
+import com.example.demo.problem.controller.request.SubmissionRequestMessageDto;
 import com.example.demo.problem.controller.response.ProblemDetailResponse;
 import com.example.demo.problem.controller.response.ProblemResponse;
-import com.example.demo.problem.controller.response.SubmissionResponse;
+import com.example.demo.problem.controller.response.SubmissionCreatedResponse;
 import com.example.demo.problem.domain.Problem;
 import com.example.demo.problem.domain.api.ProblemApiRepository;
-import com.example.demo.submission.application.SubmissionService;
 import com.example.demo.submission.domain.Submission;
+import com.example.demo.submission.domain.api.SubmissionRepository;
 import com.example.demo.testcases.domain.Testcase;
 import com.example.demo.user.domain.User;
 import com.example.demo.user.domain.api.UserApiRepository;
@@ -28,7 +25,6 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
 
@@ -40,8 +36,8 @@ public class ProblemService {
 
     private final ProblemApiRepository problemRepository;
     private final UserApiRepository userRepository;
-    private final SubmissionService submissionService;
     private final RabbitMqService rabbitMqService;
+    private final SubmissionRepository submissionRepository;
 
     @Transactional(readOnly = true)
     public List<ProblemResponse> getProblems(long start, long end) {
@@ -87,73 +83,90 @@ public class ProblemService {
         return ProblemDetailResponse.from(problem);
     }
 
+//mq쓰지 않았을 때의 기존 코드 제출 함수
 
-    public SubmissionResponse submitProblem(Long problemId, SubmissionRequest request) {
-        Problem problem = problemRepository.findById(problemId)
-                .orElseThrow(() -> new IllegalArgumentException("문제가 존재하지 않습니다."));
-        User user = userRepository.findById(request.getUserId())
-                .orElseThrow(() -> new IllegalArgumentException("유저가 존재하지 않습니다."));
+//    public SubmissionResponse submitProblem(Long problemId, SubmissionRequest request) {
+//        Problem problem = problemRepository.findById(problemId)
+//                .orElseThrow(() -> new IllegalArgumentException("문제가 존재하지 않습니다."));
+//        User user = userRepository.findById(request.getUserId())
+//                .orElseThrow(() -> new IllegalArgumentException("유저가 존재하지 않습니다."));
+//
+//        List<Testcase> testcases = new ArrayList<>();
+//        String executableCode = generateExecutableCode(request.getCode(), testcases);
+//
+//        /* Todo: 실제로 샌드박스 환경에서 실행하는 코드로 변경하고 요청을 보내야합니다.
+//        String stdout = sandboxApi.execute(executableCode);
+//        List<Boolean> testResults = Arrays.stream(
+//                        stdout.replaceAll("[\\[\\] ]", "").split(","))
+//                .map(Boolean::parseBoolean)
+//                .toList();
+//        */
+//
+//        List<SubmissionStatus> testResults = new ArrayList<>();
+//        for (int i=0; i < testcases.size(); i++) {
+//            testResults.add(SubmissionStatus.SUCCESS);
+//        }
+//
+//        double runtime =  ThreadLocalRandom.current().nextDouble(0.1, 2.0);
+//        double memory = ThreadLocalRandom.current().nextDouble(10, 100);
+//
+////        double runtime = new Random().nextDouble(0.1, 2.0); // Simulate runtime in seconds
+////        double memory = new Random().nextDouble(10, 100); // Simulate memory usage in MB
+//        sleep((int)runtime*1000); // Simulate execution time
+//
+//        // 결과 받아서 저장하기
+//        Submission submission = Submission.toEntity(
+//                request.getCode(),
+//                request.getCodingLanguage(),
+//                SubmissionStatus.SUCCESS, // 실제로는 testResults에 따라 다르게 설정해야 합니다.
+//                runtime,
+//                memory,
+//                user,
+//                problem
+//        );
+//
+//        submissionService.saveSubmissionAndLeaderboard(submission, request, user);
+//
+//        return SubmissionResponse.of(testResults);
+//    }
 
-        List<Testcase> testcases = new ArrayList<>();
-        String executableCode = generateExecutableCode(request.getCode(), testcases);
-
-        /* Todo: 실제로 샌드박스 환경에서 실행하는 코드로 변경하고 요청을 보내야합니다.
-        String stdout = sandboxApi.execute(executableCode);
-        List<Boolean> testResults = Arrays.stream(
-                        stdout.replaceAll("[\\[\\] ]", "").split(","))
-                .map(Boolean::parseBoolean)
-                .toList();
-        */
-
-        List<SubmissionStatus> testResults = new ArrayList<>();
-        for (int i=0; i < testcases.size(); i++) {
-            testResults.add(SubmissionStatus.SUCCESS);
-        }
-
-        double runtime =  ThreadLocalRandom.current().nextDouble(0.1, 2.0);
-        double memory = ThreadLocalRandom.current().nextDouble(10, 100);
-
-//        double runtime = new Random().nextDouble(0.1, 2.0); // Simulate runtime in seconds
-//        double memory = new Random().nextDouble(10, 100); // Simulate memory usage in MB
-        sleep((int)runtime*1000); // Simulate execution time
-
-        // 결과 받아서 저장하기
-        Submission submission = Submission.toEntity(
-                request.getCode(),
-                request.getCodingLanguage(),
-                SubmissionStatus.SUCCESS, // 실제로는 testResults에 따라 다르게 설정해야 합니다.
-                runtime,
-                memory,
-                user,
-                problem
-        );
-
-        submissionService.saveSubmissionAndLeaderboard(submission, request, user);
-
-        return SubmissionResponse.of(testResults);
-    }
-
-
-
-    public SubmissionResponse submitProblemWithMq(Long problemId, SubmissionRequest request) {
+    /**
+     * mq를 사용했을 때의 코드 제출 함수입니다.
+     * 문제 ID와 제출 요청을 받아서 MQ에 메시지를 보내고, 초기 상태로 SubmissionCreatedResponse를 반환합니다.
+     * @param problemId 문제 ID
+     *                  @param request 제출 요청
+     */
+    @Transactional
+    public SubmissionCreatedResponse submitProblem(Long problemId, SubmissionRequest request) {
         Problem problem = problemRepository.findById(problemId)
                 .orElseThrow(() -> new IllegalArgumentException("문제가 존재하지 않습니다."));
         User user = userRepository.findById(1L)
                 .orElseThrow(() -> new IllegalArgumentException("유저가 존재하지 않습니다."));
 
-        ProblemDto problemDto = ProblemDtoMapper.fromEntity(problem);
-        UserDto userDto = new UserDto(user.getId(), user.getNickname());
-        SubmissionMessageDto submissionMessageDto = new SubmissionMessageDto(request, userDto, problemDto);
-        rabbitMqService.sendMessage(submissionMessageDto);
+        double runtime =  ThreadLocalRandom.current().nextDouble(0.1, 2.0);
+        double memory = ThreadLocalRandom.current().nextDouble(10, 100);
 
+        Submission submission = Submission.toEntity(
+                request.getCode(),
+                request.getCodingLanguage(),
+                SubmissionStatus.PENDING, // polling 방식으로 처리하기 때문에 PENDING 상태로 저장
+                runtime,
+                memory,
+                user,
+                problem
+        );
         // MQ consumer에서 submission 저장을 한다.
-        // client에서 1~2초 간격으로 db 저장데이터를 확인한다. 그 도중에는 로딩 중 표시를 사용자에게 노출
+        // User정보와 Problem정보는 필요없기 때문에 submissionId만 보냄
+        Submission sub = submissionRepository.save(submission);
+        Long submissionId = sub.getId();
+         SubmissionRequestMessageDto messageDto = SubmissionRequestMessageDto.of(
+                 submissionId,
+                request.getContestId()
+        );
+        rabbitMqService.sendMessage(messageDto);
 
-        // waiting response 필요
-        List<SubmissionStatus> testResults = new ArrayList<>();
-        return SubmissionResponse.of(testResults);
+        return  SubmissionCreatedResponse.of(submissionId);// 초기에는 빈 리스트 반환, 실제 결과는 MQ에서 처리됨
     }
-
 
     /**
      * 샌드박스 환경에서 실행할 수 있는 Java 프로그램 코드를 생성합니다.

--- a/src/main/java/com/example/demo/problem/controller/ProblemController.java
+++ b/src/main/java/com/example/demo/problem/controller/ProblemController.java
@@ -6,7 +6,7 @@ import com.example.demo.problem.controller.request.PagingResponse;
 import com.example.demo.problem.controller.request.SubmissionRequest;
 import com.example.demo.problem.controller.response.ProblemDetailResponse;
 import com.example.demo.problem.controller.response.ProblemResponse;
-import com.example.demo.problem.controller.response.SubmissionResponse;
+import com.example.demo.problem.controller.response.SubmissionCreatedResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -49,8 +49,15 @@ public class ProblemController {
         return ApiResponse.success(problemService.getDetailProblem(problemId));
     }
 
+//    @PostMapping("/problems/{problemId}/submission")
+//    public ApiResponse<SubmissionResponse> submitProblem(
+//            @PathVariable("problemId") long problemId,
+//            @RequestBody SubmissionRequest request) {
+//        return ApiResponse.success(problemService.submitProblem(problemId, request));
+//    }
+
     @PostMapping("/problems/{problemId}/submission")
-    public ApiResponse<SubmissionResponse> submitProblem(
+    public ApiResponse<SubmissionCreatedResponse> submitCode(
             @PathVariable("problemId") long problemId,
             @RequestBody SubmissionRequest request) {
         return ApiResponse.success(problemService.submitProblem(problemId, request));

--- a/src/main/java/com/example/demo/problem/controller/request/SubmissionRequestMessageDto.java
+++ b/src/main/java/com/example/demo/problem/controller/request/SubmissionRequestMessageDto.java
@@ -1,0 +1,18 @@
+package com.example.demo.problem.controller.request;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class SubmissionRequestMessageDto {
+    private Long submissionId;
+    private Long contestId;
+
+    public static SubmissionRequestMessageDto of(Long submissionId, Long contestId) {
+        return SubmissionRequestMessageDto.builder()
+                .submissionId(submissionId)
+                .contestId(contestId)
+                .build();
+    }
+}

--- a/src/main/java/com/example/demo/problem/controller/response/SubmissionCreatedResponse.java
+++ b/src/main/java/com/example/demo/problem/controller/response/SubmissionCreatedResponse.java
@@ -1,0 +1,19 @@
+package com.example.demo.problem.controller.response;
+
+import com.example.demo.global.enums.SubmissionStatus;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class SubmissionCreatedResponse {
+    private Long submissionId;
+    private SubmissionStatus status;  // 항상 PENDING
+
+    public static SubmissionCreatedResponse of(Long submissionId) {
+        return SubmissionCreatedResponse.builder()
+                .submissionId(submissionId)
+                .status(SubmissionStatus.PENDING)
+                .build();
+    }
+}

--- a/src/main/java/com/example/demo/problem/controller/response/SubmissionResponse.java
+++ b/src/main/java/com/example/demo/problem/controller/response/SubmissionResponse.java
@@ -10,17 +10,32 @@ import java.util.List;
 @Getter
 @Builder
 public class SubmissionResponse {
-    
+    private Long submissionId;
     private SubmissionStatus status;
     private List<SubmissionStatus> testCaseStatus;
     
-    public static SubmissionResponse of(List<SubmissionStatus> status) {
-        boolean allSuccess = status.stream()
-                .allMatch(s -> s == SubmissionStatus.SUCCESS);
+    public static SubmissionResponse of(Submission submission, List<SubmissionStatus> status) {
+        // submission의 상태가 PENDING이면
+        // PENDING 상태는 테스트 케이스가 아직 실행되지 않은 상태이므로, testCaseStatus는 null로 설정
+        if (submission.getStatus() == SubmissionStatus.PENDING) {
+            return SubmissionResponse.builder()
+                    .submissionId(submission.getId())
+                    .status(submission.getStatus())
+                    .testCaseStatus(List.of(SubmissionStatus.PENDING)) // PENDING 상태로 초기화
+                    .build();
+        }
 
+        //submission의 상태가 SUCCESS이면
         return SubmissionResponse.builder()
-                .status(allSuccess ? SubmissionStatus.SUCCESS : SubmissionStatus.FAIL)
+                .submissionId(submission.getId())
+                .status(submission.getStatus())
                 .testCaseStatus(status)
                 .build();
+
+        // submission의 상태가 SUCCESS 또는 FAIL인 경우
+        // testCaseStatus는 각 테스트 케이스의 결과를 포함
+//        boolean allSuccess = status.stream()
+//                .allMatch(s -> s == SubmissionStatus.SUCCESS);
+
     }
 }

--- a/src/main/java/com/example/demo/problem/controller/response/SubmissionResultMessageDto.java
+++ b/src/main/java/com/example/demo/problem/controller/response/SubmissionResultMessageDto.java
@@ -1,0 +1,24 @@
+package com.example.demo.problem.controller.response;
+
+
+import com.example.demo.global.enums.SubmissionStatus;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+public class SubmissionResultMessageDto {
+    private Long submissionId;
+    private Long contestId;
+    private SubmissionStatus status; // "SUCCESS" or "FAIL"
+
+    public static SubmissionResultMessageDto of(Long submissionId, Long contestId, SubmissionStatus status) {
+        return SubmissionResultMessageDto.builder()
+                .submissionId(submissionId)
+                .contestId(contestId)
+                .status(status)
+                .build();
+    }
+}

--- a/src/main/java/com/example/demo/submission/application/SubmissionService.java
+++ b/src/main/java/com/example/demo/submission/application/SubmissionService.java
@@ -1,20 +1,17 @@
 package com.example.demo.submission.application;
 
-import com.example.demo.contest.domain.Contest;
 import com.example.demo.contest.domain.api.ContestRepository;
+import com.example.demo.global.enums.SubmissionStatus;
 import com.example.demo.leaderboard.application.LeaderBoardRedisService;
-import com.example.demo.leaderboard.domain.LeaderBoard;
 import com.example.demo.leaderboard.domain.api.LeaderBoardRepository;
-import com.example.demo.problem.controller.request.SubmissionRequest;
+import com.example.demo.problem.controller.response.SubmissionResponse;
 import com.example.demo.submission.domain.Submission;
 import com.example.demo.submission.domain.api.SubmissionRepository;
-import com.example.demo.user.domain.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Random;
-import java.util.concurrent.ThreadLocalRandom;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -24,27 +21,43 @@ public class SubmissionService {
     private final LeaderBoardRedisService leaderBoardRedisService;
     private final LeaderBoardRepository leaderBoardRepository;
 
-    @Transactional
-    public void saveSubmissionAndLeaderboard(Submission submission, SubmissionRequest request, User user) {
-        submissionRepository.save(submission);
-
-        Long contestId = request.getContestId();
-        if (contestId != null) {
-            Contest contest = contestRepository.findById(contestId).orElseThrow();
-//            // 테스트용 코드로 score를 500 ~ 999점 사이로 넣는다.
-//            int score = 500 + new Random().nextInt(999 - 500 + 1);
-//            // 100~ 4000 사이로 랜덤값이 나오는데 score에 따라서 계산됨.
-//            long timeTaken = (long) (4000 - (4000 - 100) * (new Random().nextInt(1000) / 999.0));
-
-            int score = ThreadLocalRandom.current().nextInt(500, 999);
-            long timeTaken = ThreadLocalRandom.current().nextLong(100, 4000);
-
-            // save user score info to Redis
-            leaderBoardRedisService.addScore(contestId,user.getId(), score);
-
-            // save leaderboard info to the RDB
-            LeaderBoard leaderBoard = LeaderBoard.toEntity(score, timeTaken, contest, user);
-            LeaderBoard save = leaderBoardRepository.save(leaderBoard);
-        }
+//    @Transactional
+//    public void saveSubmissionAndLeaderboard(Submission submission, SubmissionRequest request, User user) {
+//        submissionRepository.save(submission);
+//
+//        Long contestId = request.getContestId();
+//        if (contestId != null) {
+//            Contest contest = contestRepository.findById(contestId).orElseThrow();
+////            // 테스트용 코드로 score를 500 ~ 999점 사이로 넣는다.
+////            int score = 500 + new Random().nextInt(999 - 500 + 1);
+////            // 100~ 4000 사이로 랜덤값이 나오는데 score에 따라서 계산됨.
+////            long timeTaken = (long) (4000 - (4000 - 100) * (new Random().nextInt(1000) / 999.0));
+//
+//            int score = ThreadLocalRandom.current().nextInt(500, 999);
+//            long timeTaken = ThreadLocalRandom.current().nextLong(100, 4000);
+//
+//            // save user score info to Redis
+//            leaderBoardRedisService.addScore(contestId,user.getId(), score);
+//
+//            // save leaderboard info to the RDB
+//            LeaderBoard leaderBoard = LeaderBoard.toEntity(score, timeTaken, contest, user);
+//            LeaderBoard save = leaderBoardRepository.save(leaderBoard);
+//        }
+//    }
+    public Submission getSubmission(Long submissionId) {
+        return submissionRepository.findById(submissionId)
+                .orElseThrow(() -> new IllegalArgumentException("Submission not found with id: " + submissionId));
     }
+
+    /**
+     * 제출 상태를 가져오는 메소드입니다.
+     * @param submissionId 제출 ID
+     * @return SubmissionResponse 객체
+     */
+    @Transactional(readOnly = true)
+    public SubmissionResponse getSubmissionStatus(Long submissionId) {
+        Submission submission = getSubmission(submissionId);
+        return SubmissionResponse.of(submission, List.of(SubmissionStatus.SUCCESS));
+    }
+
 }

--- a/src/main/java/com/example/demo/submission/application/SubmissionService.java
+++ b/src/main/java/com/example/demo/submission/application/SubmissionService.java
@@ -46,7 +46,7 @@ public class SubmissionService {
 //    }
     public Submission getSubmission(Long submissionId) {
         return submissionRepository.findById(submissionId)
-                .orElseThrow(() -> new IllegalArgumentException("Submission not found with id: " + submissionId));
+                .orElseThrow(() -> new IllegalArgumentException("Submission with id=" + submissionId + " not found"));
     }
 
     /**

--- a/src/main/java/com/example/demo/submission/controller/SubmissionController.java
+++ b/src/main/java/com/example/demo/submission/controller/SubmissionController.java
@@ -1,0 +1,22 @@
+package com.example.demo.submission.controller;
+
+import com.example.demo.global.common.ApiResponse;
+import com.example.demo.problem.controller.response.SubmissionResponse;
+import com.example.demo.submission.application.SubmissionService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class SubmissionController {
+    private final SubmissionService submissionService;
+
+
+    @GetMapping("/submissions/{submissionId}")
+    public ApiResponse<SubmissionResponse> getSubmissionStatus(
+            @PathVariable Long submissionId) {
+        return ApiResponse.success(submissionService.getSubmissionStatus(submissionId));
+    }
+}

--- a/src/main/java/com/example/demo/submission/domain/Submission.java
+++ b/src/main/java/com/example/demo/submission/domain/Submission.java
@@ -1,9 +1,9 @@
 package com.example.demo.submission.domain;
 
-import com.example.demo.user.domain.User;
 import com.example.demo.global.enums.CodingLanguages;
 import com.example.demo.global.enums.SubmissionStatus;
 import com.example.demo.problem.domain.Problem;
+import com.example.demo.user.domain.User;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -12,13 +12,21 @@ import java.time.LocalDateTime;
 @Entity
 @Table(name = "submission")
 @Getter
+@Setter
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
 public class Submission {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @SequenceGenerator(
+            name = "submission_seq",
+            sequenceName = "submission_seq"
+    )
+    @GeneratedValue(
+            strategy = GenerationType.SEQUENCE,
+            generator = "submission_seq"
+    )
     private Long id;
 
     private String code;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -39,10 +39,22 @@ spring:
 #    password: guest # RabbitMQ 웹 관리 콘솔 비밀번호
 
 rabbitmq:
-  queue:
-    name: test-queue # 사용할 queue 이름
+  # 큐 이름
+  request:
+    queue:
+      name: submission-request-queue
+    routing:
+      key: submission-request-route
+
+  result:
+    queue:
+      name: submission-result-queue
+    routing:
+      key: submission-result-route
+
+  # 교환기 이름
   exchange:
-    name: test-exchange # 사용할 exchange 이름
+    name: submission-exchange
   routing:
     key: test-key
 #  queue:

--- a/src/test/java/com/example/demo/problem/service/ProblemServiceTest.java
+++ b/src/test/java/com/example/demo/problem/service/ProblemServiceTest.java
@@ -1,16 +1,40 @@
 package com.example.demo.problem.service;
 
+import com.example.demo.global.enums.Catagories;
+import com.example.demo.global.enums.Diffculties;
+import com.example.demo.global.enums.SubmissionStatus;
+import com.example.demo.global.rabbitmq.RabbitMqService;
 import com.example.demo.problem.application.ProblemService;
+import com.example.demo.problem.controller.request.SubmissionRequest;
+import com.example.demo.problem.controller.request.SubmissionRequestMessageDto;
 import com.example.demo.problem.controller.response.ProblemResponse;
+import com.example.demo.problem.controller.response.SubmissionCreatedResponse;
+import com.example.demo.problem.domain.Problem;
+import com.example.demo.problem.domain.api.ProblemApiRepository;
+import com.example.demo.submission.domain.Submission;
+import com.example.demo.submission.domain.api.SubmissionRepository;
+import com.example.demo.user.domain.User;
+import com.example.demo.user.domain.api.UserApiRepository;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
+import org.mockito.ArgumentCaptor;
+import org.mockito.ArgumentMatchers;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.test.util.ReflectionTestUtils;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
+
+import static com.example.demo.global.enums.CodingLanguages.JAVA;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class ProblemServiceTest {
 
@@ -18,9 +42,17 @@ public class ProblemServiceTest {
     @SpringBootTest
     class ProblemPerformanceTest {
 
-        @Autowired
-        private ProblemService problemService;
 
+        @Mock
+        SubmissionRepository submissionRepository;
+        @Mock
+        ProblemApiRepository problemRepository;
+        @Mock
+        UserApiRepository userRepository;
+        @Mock
+        RabbitMqService rabbitMqService;
+        @InjectMocks
+        ProblemService problemService;
 
         @Test
         void testCursorPagingPerformance() {
@@ -58,6 +90,48 @@ public class ProblemServiceTest {
 
             long end = System.currentTimeMillis();
             System.out.printf("✅ 오프셋 기반 페이지 전체 조회 시간: %dms, 총 조회된 개수: %d건\n", (end - start), totalFetched);
+        }
+
+        @Test
+        void submitProblem_persistsAndSendsMessage() {
+            // given
+            long problemId = 42L;
+            SubmissionRequest req = new SubmissionRequest(JAVA,7L, "JAVA", 7L);
+            Problem problem = new Problem(
+                    1L,                                            // id
+                    "Sample Problem Title",                        // title
+                    "This is a sample problem description.",      // description
+                   Diffculties.EASY,                             // difficulty (enum)
+                    Catagories.ARRAY,                            // category (enum)
+                    "Time limit: 1s, Memory limit: 256MB",         // constraints
+                    new ArrayList<>(),                             // examples (빈 리스트로 시작)
+                    new ArrayList<>(),                             // startercodes (빈 리스트로 시작)
+                    new ArrayList<>()                              // testcases (빈 리스트로 시작)
+            );
+            User user = User.toEntity(1L, "alice");
+
+            when(problemRepository.findById(problemId)).thenReturn(Optional.of(problem));
+            when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+            // simulate save → id 채워진 객체 반환
+            when(submissionRepository.save(ArgumentMatchers.any()))
+                    .thenAnswer(invocation -> {
+                        Submission s = invocation.getArgument(0);
+                        ReflectionTestUtils.setField(s, "id", 123L);
+                        return s;
+                    });
+
+            // when
+            SubmissionCreatedResponse resp = problemService.submitProblem(problemId, req);
+
+            // then
+            assertThat(resp.getSubmissionId()).isEqualTo(123L);
+            assertThat(resp.getStatus()).isEqualTo(SubmissionStatus.PENDING);
+            // 메시지 발송 검증
+            ArgumentCaptor<SubmissionRequestMessageDto> captor =
+                    ArgumentCaptor.forClass(SubmissionRequestMessageDto.class);
+            verify(rabbitMqService).sendMessage(captor.capture());
+            assertThat(captor.getValue().getSubmissionId()).isEqualTo(123L);
+            assertThat(captor.getValue().getContestId()).isEqualTo(7L);
         }
 
     }

--- a/src/test/java/com/example/demo/problem/service/ProblemServiceTest.java
+++ b/src/test/java/com/example/demo/problem/service/ProblemServiceTest.java
@@ -36,103 +36,100 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+@SpringBootTest
 public class ProblemServiceTest {
 
-    @Nested
-    @SpringBootTest
-    class ProblemPerformanceTest {
 
+    @Mock
+    SubmissionRepository submissionRepository;
+    @Mock
+    ProblemApiRepository problemRepository;
+    @Mock
+    UserApiRepository userRepository;
+    @Mock
+    RabbitMqService rabbitMqService;
+    @InjectMocks
+    ProblemService problemService;
 
-        @Mock
-        SubmissionRepository submissionRepository;
-        @Mock
-        ProblemApiRepository problemRepository;
-        @Mock
-        UserApiRepository userRepository;
-        @Mock
-        RabbitMqService rabbitMqService;
-        @InjectMocks
-        ProblemService problemService;
+    @Test
+    void testCursorPagingPerformance() {
+        long cursor = 999900L;
+        int size = 100;
+        long totalFetched = 0;
+        long start = System.currentTimeMillis();
 
-        @Test
-        void testCursorPagingPerformance() {
-            long cursor = 999900L;
-            int size = 100;
-            long totalFetched = 0;
-            long start = System.currentTimeMillis();
+        List<ProblemResponse> problems = problemService.getProblemsByCursor(cursor, size);
 
-                List<ProblemResponse> problems = problemService.getProblemsByCursor(cursor, size);
+        totalFetched += problems.size();
 
-                totalFetched += problems.size();
+        // 다음 커서를 설정
+        cursor = problems.get(problems.size() - 1).getId();
+        System.out.printf("%d 번째에서 %d 번째까지 조회: %d건\n", cursor,cursor+size, problems.size());
 
-                // 다음 커서를 설정
-                cursor = problems.get(problems.size() - 1).getId();
-                System.out.printf("%d 번째에서 %d 번째까지 조회: %d건\n", cursor,cursor+size, problems.size());
-
-            long end = System.currentTimeMillis();
-            System.out.printf("✅ 커서 기반 페이지 전체 조회 시간: %dms, 총 조회된 개수: %d건\n", (end - start), totalFetched);
-        }
-
-        @Test
-        void testOffsetPagingPerformance() {
-            int page = 9999;
-            int size = 100;
-            long totalFetched = 0;
-            long start = System.currentTimeMillis();
-
-                // 페이지 요청
-                Pageable pageable = PageRequest.of(page, size);
-                Page<ProblemResponse> problemPage = problemService.getProblemPage(pageable);
-
-
-                totalFetched += problemPage.getNumberOfElements();
-                System.out.printf("%d 번째에서 %d 번째까지 조회: %d건\n", page*size,(page+1)*size, problemPage.getNumberOfElements());
-
-            long end = System.currentTimeMillis();
-            System.out.printf("✅ 오프셋 기반 페이지 전체 조회 시간: %dms, 총 조회된 개수: %d건\n", (end - start), totalFetched);
-        }
-
-        @Test
-        void submitProblem_persistsAndSendsMessage() {
-            // given
-            long problemId = 42L;
-            SubmissionRequest req = new SubmissionRequest(JAVA,7L, "JAVA", 7L);
-            Problem problem = new Problem(
-                    1L,                                            // id
-                    "Sample Problem Title",                        // title
-                    "This is a sample problem description.",      // description
-                   Diffculties.EASY,                             // difficulty (enum)
-                    Catagories.ARRAY,                            // category (enum)
-                    "Time limit: 1s, Memory limit: 256MB",         // constraints
-                    new ArrayList<>(),                             // examples (빈 리스트로 시작)
-                    new ArrayList<>(),                             // startercodes (빈 리스트로 시작)
-                    new ArrayList<>()                              // testcases (빈 리스트로 시작)
-            );
-            User user = User.toEntity(1L, "alice");
-
-            when(problemRepository.findById(problemId)).thenReturn(Optional.of(problem));
-            when(userRepository.findById(1L)).thenReturn(Optional.of(user));
-            // simulate save → id 채워진 객체 반환
-            when(submissionRepository.save(ArgumentMatchers.any()))
-                    .thenAnswer(invocation -> {
-                        Submission s = invocation.getArgument(0);
-                        ReflectionTestUtils.setField(s, "id", 123L);
-                        return s;
-                    });
-
-            // when
-            SubmissionCreatedResponse resp = problemService.submitProblem(problemId, req);
-
-            // then
-            assertThat(resp.getSubmissionId()).isEqualTo(123L);
-            assertThat(resp.getStatus()).isEqualTo(SubmissionStatus.PENDING);
-            // 메시지 발송 검증
-            ArgumentCaptor<SubmissionRequestMessageDto> captor =
-                    ArgumentCaptor.forClass(SubmissionRequestMessageDto.class);
-            verify(rabbitMqService).sendMessage(captor.capture());
-            assertThat(captor.getValue().getSubmissionId()).isEqualTo(123L);
-            assertThat(captor.getValue().getContestId()).isEqualTo(7L);
-        }
-
+        long end = System.currentTimeMillis();
+        System.out.printf("✅ 커서 기반 페이지 전체 조회 시간: %dms, 총 조회된 개수: %d건\n", (end - start), totalFetched);
     }
+
+    @Test
+    void testOffsetPagingPerformance() {
+        int page = 9999;
+        int size = 100;
+        long totalFetched = 0;
+        long start = System.currentTimeMillis();
+
+        // 페이지 요청
+        Pageable pageable = PageRequest.of(page, size);
+        Page<ProblemResponse> problemPage = problemService.getProblemPage(pageable);
+
+
+        totalFetched += problemPage.getNumberOfElements();
+        System.out.printf("%d 번째에서 %d 번째까지 조회: %d건\n", page*size,(page+1)*size, problemPage.getNumberOfElements());
+
+        long end = System.currentTimeMillis();
+        System.out.printf("✅ 오프셋 기반 페이지 전체 조회 시간: %dms, 총 조회된 개수: %d건\n", (end - start), totalFetched);
+    }
+
+    @Test
+    void submitProblem_persistsAndSendsMessage() {
+        // given
+        long problemId = 42L;
+        SubmissionRequest req = new SubmissionRequest(JAVA,7L, "JAVA", 7L);
+        Problem problem = new Problem(
+                1L,                                            // id
+                "Sample Problem Title",                        // title
+                "This is a sample problem description.",      // description
+                Diffculties.EASY,                             // difficulty (enum)
+                Catagories.ARRAY,                            // category (enum)
+                "Time limit: 1s, Memory limit: 256MB",         // constraints
+                new ArrayList<>(),                             // examples (빈 리스트로 시작)
+                new ArrayList<>(),                             // startercodes (빈 리스트로 시작)
+                new ArrayList<>()                              // testcases (빈 리스트로 시작)
+        );
+        User user = User.toEntity(1L, "alice");
+
+        when(problemRepository.findById(problemId)).thenReturn(Optional.of(problem));
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+        // simulate save → id 채워진 객체 반환
+        when(submissionRepository.save(ArgumentMatchers.any()))
+                .thenAnswer(invocation -> {
+                    Submission s = invocation.getArgument(0);
+                    ReflectionTestUtils.setField(s, "id", 123L);
+                    return s;
+                });
+
+        // when
+        SubmissionCreatedResponse resp = problemService.submitProblem(problemId, req);
+
+        // then
+        assertThat(resp.getSubmissionId()).isEqualTo(123L);
+        assertThat(resp.getStatus()).isEqualTo(SubmissionStatus.PENDING);
+        // 메시지 발송 검증
+        ArgumentCaptor<SubmissionRequestMessageDto> captor =
+                ArgumentCaptor.forClass(SubmissionRequestMessageDto.class);
+        verify(rabbitMqService).sendMessage(captor.capture());
+        assertThat(captor.getValue().getSubmissionId()).isEqualTo(123L);
+        assertThat(captor.getValue().getContestId()).isEqualTo(7L);
+    }
+
 }
+

--- a/src/test/java/com/example/demo/submission/RabbitMqServiceTest.java
+++ b/src/test/java/com/example/demo/submission/RabbitMqServiceTest.java
@@ -1,0 +1,59 @@
+package com.example.demo.submission;
+
+import com.example.demo.global.enums.SubmissionStatus;
+import com.example.demo.global.rabbitmq.RabbitMqService;
+import com.example.demo.leaderboard.application.LeaderBoardService;
+import com.example.demo.problem.controller.response.SubmissionResultMessageDto;
+import com.example.demo.submission.domain.Submission;
+import com.example.demo.submission.domain.api.SubmissionRepository;
+import com.example.demo.user.domain.User;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class RabbitMqServiceTest {
+
+    @Mock
+    SubmissionRepository submissionRepository;
+    @Mock
+    LeaderBoardService leaderboardService;
+    @InjectMocks
+    RabbitMqService  rabbitMqService;
+
+    @Test
+    void handleResult_updatesStatusAndCallsLeaderboard() {
+        // given
+        long submissionId = 99L;
+        Submission existing = new Submission();
+        ReflectionTestUtils.setField(existing, "id", submissionId);
+        existing.setStatus(SubmissionStatus.PENDING);
+        User user = User.toEntity(1L, "alice");
+        existing.setUser(user);
+        when(submissionRepository.findById(submissionId))
+                .thenReturn(Optional.of(existing));
+
+        SubmissionResultMessageDto msg =
+                SubmissionResultMessageDto.of(submissionId, 7L ,SubmissionStatus.SUCCESS);
+
+        // when
+        rabbitMqService.handleResult(msg);
+
+        // then
+        // 엔티티 상태가 SUCCESS로 바뀌었는지
+        assertThat(existing.getStatus()).isEqualTo(SubmissionStatus.SUCCESS);
+        // 저장 호출 검증
+        verify(submissionRepository).save(existing);
+        // 리더보드 서비스 호출 검증
+        verify(leaderboardService).saveLeaderboard(7L, user);
+    }
+}

--- a/src/test/java/com/example/demo/submission/RabbitMqServiceTest.java
+++ b/src/test/java/com/example/demo/submission/RabbitMqServiceTest.java
@@ -38,12 +38,13 @@ class RabbitMqServiceTest {
         ReflectionTestUtils.setField(existing, "id", submissionId);
         existing.setStatus(SubmissionStatus.PENDING);
         User user = User.toEntity(1L, "alice");
+        Long contestId = 7L;
         existing.setUser(user);
         when(submissionRepository.findById(submissionId))
                 .thenReturn(Optional.of(existing));
 
         SubmissionResultMessageDto msg =
-                SubmissionResultMessageDto.of(submissionId, 7L ,SubmissionStatus.SUCCESS);
+                SubmissionResultMessageDto.of(submissionId, contestId ,SubmissionStatus.SUCCESS);
 
         // when
         rabbitMqService.handleResult(msg);
@@ -54,6 +55,6 @@ class RabbitMqServiceTest {
         // 저장 호출 검증
         verify(submissionRepository).save(existing);
         // 리더보드 서비스 호출 검증
-        verify(leaderboardService).saveLeaderboard(7L, user);
+        verify(leaderboardService).saveLeaderboard(contestId, user);
     }
 }


### PR DESCRIPTION
### 이번 PR에서는 기존 동기식 코드 실행 로직을 RabbitMQ를 활용한 비동기 처리로 전환하고, 제출 상태 폴링(polling)용 API를 추가했습니다.

주요 변경 사항

### SubmissionStatus 확장

PENDING 상태 추가: 초기 제출 시 PENDING으로 저장

### RabbitMQ 설정 및 활성화

@EnableRabbit 애노테이션 추가

application.yml에 요청/결과용 큐(request/result) 및 라우팅 키 분리

RabbitMqConfig에서 Request/Result 큐·바인딩·Listener 팩토리 구성

### 비동기 메시지 발송(Service → MQ)

ProblemService.submitProblem()

Submission 엔티티를 먼저 저장하고 PENDING 상태로 반환

SubmissionRequestMessageDto를 통해 MQ로 메시지 전송

비동기 메시지 발송이기에 MQ에 메시지를 전송 후 바로 submissionId를 사용자에게 바로 반환

### 비동기 결과 처리(MQ → Service)

RabbitMqService.handleResult()

SubmissionResultMessageDto 수신 후 해당 Submission 상태 업데이트

LeaderBoardService.saveLeaderboard() 호출로 리더보드 저장

### 폴링용 상태 조회 API 추가

SubmissionController에 /submissions/{submissionId} 엔드포인트 신설

SubmissionService.getSubmissionStatus()에서 현재 상태(및 테스트 케이스 결과) 반환
